### PR TITLE
Add 'Seeker' model

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import User, Apartment, City, Hobby
+from .models import User, Apartment, City, Hobby, Seeker
 from django.contrib.auth.admin import UserAdmin
 
 
@@ -49,3 +49,9 @@ class CityAdminConfig(admin.ModelAdmin):
 @admin.register(Hobby)
 class HobbyAdminConfig(admin.ModelAdmin):
     list_display = ('name',)
+
+
+@admin.register(Seeker)
+class SeekerAdminConfig(admin.ModelAdmin):
+    list_display = ('base_user', 'city', 'start_date', 'min_rent', 'max_rent',
+                    'num_of_roomates', 'num_of_rooms', 'about')

--- a/users/models.py
+++ b/users/models.py
@@ -109,3 +109,17 @@ class Apartment(models.Model):
 
     def __str__(self):
         return f"Owner:{self.owner}, Addres:{self.address}, City:{self.city}"
+
+
+class Seeker(models.Model):
+    base_user = models.OneToOneField(AUTH_USER_MODEL, on_delete=models.CASCADE, primary_key=True)
+    city = models.ForeignKey(City, on_delete=models.RESTRICT, related_name='city_seekers')
+    start_date = models.DateField()
+    min_rent = models.IntegerField()
+    max_rent = models.IntegerField()
+    num_of_roomates = models.IntegerField()
+    num_of_rooms = models.IntegerField()
+    about = models.TextField(blank=True, max_length=300)
+
+    def __str__(self):
+        return f"Seeker:{self.base_user}"


### PR DESCRIPTION
In order to build our ORM we add the `Seeker` class.

The Seeker class extends (OneToOne) the base User class.
The class fields gather the seeker's 'wanted' apartment data such as:

- city
- start date
- min\max rent
- etc.

In addition, the class will be registered to the admin page.

fixes #44 
