### PR TITLE
Adding is_seeker/owner properties to User model

### DIFF
--- a/contacts/migrations/0002_test_data.py
+++ b/contacts/migrations/0002_test_data.py
@@ -1,5 +1,6 @@
 from django.db import migrations, transaction
-from users.models import Apartment, Seeker
+from users.models import Seeker
+from apartments.models import Apartment
 from contacts.models import Connection
 
 

--- a/users/models.py
+++ b/users/models.py
@@ -86,6 +86,20 @@ class User(AbstractBaseUser, PermissionsMixin):
     def __str__(self):
         return self.email
 
+    @property
+    def is_seeker(self):
+        try:
+            return self.seeker is not None
+        except AttributeError:
+            return False
+
+    @property
+    def is_owner(self):
+        try:
+            return self.apartment is not None
+        except AttributeError:
+            return False
+
 
 class Seeker(models.Model):
     base_user = models.OneToOneField(AUTH_USER_MODEL, on_delete=models.CASCADE, primary_key=True)

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,5 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.db import transaction, IntegrityError
+from .models import Seeker
+from apartments.models import Apartment
 import pytest
 
 
@@ -84,3 +86,25 @@ def test_user_blank_fields(email_field, first_name_field, last_name_field, birth
             get_user_model().objects.create_user(
                 email_field, first_name_field, last_name_field, birth_day_field, 'password'
             )
+
+
+@pytest.fixture
+def seeker_profile_as_user():
+    return Seeker.objects.first().base_user
+
+
+@pytest.fixture
+def owner_profile_as_user():
+    return Apartment.objects.first().owner
+
+
+@pytest.mark.django_db
+def test_is_seeker(seeker_profile_as_user, owner_profile_as_user):
+    assert seeker_profile_as_user.is_seeker is True
+    assert owner_profile_as_user.is_seeker is False
+
+
+@pytest.mark.django_db
+def test_is_owner(seeker_profile_as_user, owner_profile_as_user):
+    assert owner_profile_as_user.is_owner is True
+    assert seeker_profile_as_user.is_owner is False


### PR DESCRIPTION
- Add is_seeker and is_owner properties to the 'User' model in order to
enable a quick way to check what is the type of user.
- Add test for these methods.

fix #83 