### PR TITLE
Add pull request templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+# Description
+<!---Describe your changes in detail. What things did you change?-->
+
+## Screenshots
+<!---Add screenshots if applicable-->
+
+## Manual Tests
+<!---Did you run any manual tests on your PR? PyTest tests don't count.-->
+
+## Additional Information
+<!---Post here any additional information about this PR. For example links to new technologies used in this PR, changes needed to documentation etc.-->
+
+### Issues close by this PR
+<!---If this PR closes any issues, list them here using "Fixes #<ISSUE_NO>"-->
+
+### PR Dependencies
+<!---If this PR is dependent on other PRs, list them here using "Depends on #<PR_NO>" -->


### PR DESCRIPTION
# Description
Pull request templates make PR descriptions easier to read and understand. After adding pull request templates to our repository, project contributors will automatically see the template's contents in the pull request body.
The template in this PR description is the template that we'll be using.

## Screenshots
(Here you should attach screenshots related to this PR, if there are any.)

## Manual Tests
(Here you should list a list of **manual** tests you've done.)

## Additional Information
(Here you should list additional information about the PR, such as new technologies used, or whether the documentation needs to be updated)

More information about PR templates [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)

### Issues close by this PR
(Here you should list the issues this PR closes)

### PR Dependencies
(Here you should list the PRs which this PR depends on)