### PR TITLE
Fixing logout redirect in the navbar

### DIFF
--- a/main/templates/main/base_template.html
+++ b/main/templates/main/base_template.html
@@ -17,7 +17,7 @@
       <a class="navbar-brand" href="/">
           <img src="../../static/img/navbar-logo.png" alt="roo.me" id="logo">
       </a>
-      <a href="logout" class="btn align-middle btn-primary ml-auto mr-3 order-lg-last" type="button">Log out</a>
+      <a href="/logout" class="btn align-middle btn-primary ml-auto mr-3 order-lg-last" type="button">Log out</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNav">
         <span class="navbar-toggler-icon"></span>
       </button>


### PR DESCRIPTION
# Description
Fixing the navbar redirect when clicking the logout link.
Previously : It would add '/logout/' to the current url.
Now: Redirects to '/logout/'.
### Issues close by this PR
fix #132 
