### PR TITLE
Adding a decorator to assert a user is not logged

### DIFF
--- a/apartments/tests.py
+++ b/apartments/tests.py
@@ -91,3 +91,13 @@ def test_register_apartment_view(client):
     url = reverse('register_apartment')
     response = client.get(url)
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_accessing_apartment_register_view_with_logged_user(client, user_model):
+    client.login(email='email@address.com', password='password')
+    url = reverse('register_apartment')
+    response = client.get(url)
+    assert response.status_code == 302
+    response = client.get(response.url)
+    assert response.status_code == 200

--- a/apartments/views.py
+++ b/apartments/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
 from users.forms import UserCreationForm
+from main.decorators import not_logged_in_required
 from .forms import (ApartmentDetailsUpdateForm,
                     ApartmentQualitiesUpdateForm,
                     ApartmentCreationForm,)
@@ -30,6 +31,7 @@ def updateApartment(request):
     return render(request, 'apartments/update-apartment.html', context)
 
 
+@not_logged_in_required(redirect_to='home')
 def register_apartment(request):
     if request.method == 'POST':
         user_creation_form = UserCreationForm(request.POST)

--- a/main/decorators.py
+++ b/main/decorators.py
@@ -1,0 +1,12 @@
+from django.shortcuts import redirect
+
+
+def not_logged_in_required(redirect_to='home'):
+    def decorator(view_func):
+        def wrapper(request, *args, **kwargs):
+            if request.user.is_authenticated:
+                return redirect(redirect_to)
+            else:
+                return view_func(request, *args, **kwargs)
+        return wrapper
+    return decorator

--- a/seekers/tests.py
+++ b/seekers/tests.py
@@ -49,3 +49,13 @@ def test_register_apartment_view(client):
     url = reverse('register_seeker')
     response = client.get(url)
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_accessing_seeker_register_view_with_logged_user(client, user_model):
+    client.login(email='email@address.com', password='password')
+    url = reverse('register_seeker')
+    response = client.get(url)
+    assert response.status_code == 302
+    response = client.get(response.url)
+    assert response.status_code == 200

--- a/seekers/views.py
+++ b/seekers/views.py
@@ -1,8 +1,10 @@
 from django.shortcuts import render, redirect
 from users.forms import UserCreationForm
 from .forms import SeekerCreationForm
+from main.decorators import not_logged_in_required
 
 
+@not_logged_in_required(redirect_to='home')
 def register_seeker(request):
     if request.method == 'POST':
         user_creation_form = UserCreationForm(request.POST)


### PR DESCRIPTION
# Description
Adding a decorator to assert a user is not logged

Added the decorator in main.decorators.
Added the new decorator to the register views of Seeker
and Apartment.
Added tests to assert the decorator is working properly.

This PR is dependent on #147 - merged

used following refernces:
https://www.youtube.com/watch?v=eBsc65jTKvw&t=766s
https://docs.djangoproject.com/en/3.2/ref/contrib/auth/
https://www.datacamp.com/community/tutorials/decorators-python

## Screenshots
![image](https://user-images.githubusercontent.com/79044795/117153431-a1389500-adc3-11eb-84fe-187d3267d621.png)


## Manual Tests
Did some tests to see that the decorator is working as intended

## Additional Information
Found a bug/issue with flake8, when i tried to import a fixture and use it flake8 was confused:
![flake_error](https://user-images.githubusercontent.com/79044795/117153664-de9d2280-adc3-11eb-923b-bca674b684c1.png)

We will probably have to redisign the fixtures in all the tests files, for now I added  `# noqa: F811` and `# noqa: F401` to
make flake8 ignore those false positives...
https://stackoverflow.com/questions/47196947/py-test-deal-with-both-pylint-and-flake8-when-importing-features-from-a-module

### Issues close by this PR
Fix #137 
