### PR TITLE
Adding 'apartments-details' view

### DIFF
--- a/apartments/templates/apartments/apartment-details.html
+++ b/apartments/templates/apartments/apartment-details.html
@@ -1,0 +1,56 @@
+{% extends "main/base_template.html" %}
+{% block content %}
+
+<div class="card">
+    <div class="card-body">
+        <div class="row">
+            <div class="col-6">
+                <h5 class="card-title">Apartment Details</h5>
+                <h6 class="card-subtitle mb-2 text-muted">owner: <a href="#">{{ apartment.owner }}</a></h6>
+            </div>
+            <div class="col-6" style="text-align: right;">
+                {% if request.user == apartment.owner %}
+                <a href="{% url 'apartment-update' %}" class="btn btn-primary">Update</a>
+                {% elif apartment.is_relevant %}
+                <a href="#" class="card-link">V icon</a>
+                <a href="#" class="card-link">X icon</a>
+                {% endif %}
+
+                {% if not apartment.is_relevant %}
+                <p class="card-text">This apartment is not relevant anymore</p>
+                {% endif %}
+            </div>
+        </div>
+
+        <dl class="row">
+            <dt class="col-sm-3">City</dt>
+            <dd class="col-sm-9">{{ apartment.city }}</dd>
+
+            <dt class="col-sm-3">Address</dt>
+            <dd class="col-sm-9">{{ apartment.address }}</dd>
+
+            <dt class="col-sm-3">Rent</dt>
+            <dd class="col-sm-9">{{ apartment.rent }}</dd>
+
+            <dt class="col-sm-3 text-truncate">Number of Roomates</dt>
+            <dd class="col-sm-9">{{ apartment.num_of_roomates }}</dd>
+
+            <dt class="col-sm-3 text-truncate">Number of Rooms</dt>
+            <dd class="col-sm-9">{{ apartment.num_of_rooms }}</dd>
+
+            <dt class="col-sm-3 text-truncate">Start Date</dt>
+            <dd class="col-sm-9">{{ apartment.start_date }}</dd>
+
+            <dt class="col-sm-3 text-truncate">About</dt>
+            <dd class="col-sm-9"> {{ apartment.aboute }}</dd>
+        </dl>
+        <small class="text-muted">posted in {{ apartment.date_posted }}</small>
+    <div class="card-img">
+        <img src='{{ apartment.image_url }}' style="width: 80%;">
+    </div>
+    </div>
+</div>
+
+
+
+{% endblock %}

--- a/apartments/tests.py
+++ b/apartments/tests.py
@@ -42,6 +42,20 @@ class TestViews:
         response = client.get(response.url)
         assert response.status_code == 200
 
+    def test_apartment_details_view_to_valid_apartment_id(self, client, apartment_model):
+        client.login(email='apartmentemail@address.com', password='password')
+        path = '/apartments/' + str(apartment_model.owner.id) + '/details'
+        response = client.get(path)
+        assert response.status_code == 200
+
+    def test_apartment_details_view_to_invalid_apartment_id(self, client, apartment_model):
+        client.login(email='apartmentemail@address.com', password='password')
+        path = '/apartments/0/details'
+        response = client.get(path)
+        assert response.status_code == 302
+        response = client.get(response.url)
+        assert response.status_code == 200
+
 
 @pytest.mark.parametrize(
     'city, address, rent, num_of_roomates, num_of_rooms, start_date, about, validity',

--- a/apartments/urls.py
+++ b/apartments/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from . import views as apartment_views
 
 urlpatterns = [
-    path('update', apartment_views.updateApartment, name='apartment-update'),
+    path('update', apartment_views.update_apartment, name='apartment-update'),
     path('register/', apartment_views.register_apartment, name='register_apartment'),
+    path('<int:apartment_id>/details', apartment_views.apartment_details, name='apartment-details'),
 ]

--- a/apartments/views.py
+++ b/apartments/views.py
@@ -4,10 +4,12 @@ from users.forms import UserCreationForm
 from .forms import (ApartmentDetailsUpdateForm,
                     ApartmentQualitiesUpdateForm,
                     ApartmentCreationForm,)
+from .models import Apartment
+import main
 
 
 @login_required
-def updateApartment(request):
+def update_apartment(request):
     if request.user.is_owner is False:
         return redirect('home')
 
@@ -48,3 +50,15 @@ def register_apartment(request):
         "uform": user_creation_form,
         "aform": apartment_creation_form,
         })
+
+
+@login_required()
+def apartment_details(request, apartment_id):
+    apartment_to_view = Apartment.get_apartment_by_id(apartment_id)
+
+    if apartment_to_view is None:
+        return redirect(main.views.home)
+
+    return render(request, 'apartments/apartment-details.html', {
+         'apartment': apartment_to_view,
+         })

--- a/main/templates/main/base_template.html
+++ b/main/templates/main/base_template.html
@@ -47,7 +47,7 @@
         {% block sidebar %}
         {% endblock %}
       </div>
-      <div class="col-md-10">
+      <div class="col-md-9">
         {% block content %}
         {% endblock %}  
       </div>


### PR DESCRIPTION

# Description
- Adding a view and template to display all the data about a specific apartment.
- Adding a URL on the apartments app.
- Adding a test to demonstrate a user's entry into an existing apartment details view and a test to an apartment that does not exist.

## Screenshots
<img width="948" alt="Capture" src="https://user-images.githubusercontent.com/65215909/117511605-aef24400-af96-11eb-9449-ebe1905020c8.PNG">

## Additional Information
We may need to make changes to the template when we choose a V and X icon in the future.

### Issues close by this PR
#145 