### PR TITLE
Redirect logout page to landing page

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -6,5 +6,5 @@ urlpatterns = [
     path('', views.home, name='home'),
     path('register/', views.register, name='register'),
     path('login/', auth_views.LoginView.as_view(template_name='main/login.html'), name='login'),
-    path('logout/', auth_views.LogoutView.as_view(template_name='main/logout.html'), name='logout'),
+    path('logout/', auth_views.LogoutView.as_view(template_name='main/landing_page.html'), name='logout'),
 ]


### PR DESCRIPTION
# Description
After discussing the issue in a zoom meeting, we have decided to remove the logout page from the application.
When clicking the logout button, the landing page will be displayed. See screenshot below.

I left `logout.html` in the repo on purpose, for now. This is in case we ever want to go back to the logout page.

## Screenshots
Notice the URL bar.

![Screen Shot 2021-05-10 at 15 48 31](https://user-images.githubusercontent.com/53123142/117661589-33b3ac80-b1a7-11eb-870c-fae51bc33c42.png)

### Additional Information
Sorry Daniel

### Issues close by this PR
Fixes #157