### PR TITLE
Fix spelling in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 ## Additional Information
 <!---Post here any additional information about this PR. For example links to new technologies used in this PR, changes needed to documentation etc.-->
 
-### Issues close by this PR
+### Issues closed by this PR
 <!---If this PR closes any issues, list them here using "Fixes #<ISSUE_NO>"-->
 
 ### PR Dependencies


### PR DESCRIPTION
# Description
Missed a 'd' in one of the titles.