### PR TITLE
Update routing at homepage for seekers and owners

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -3,7 +3,8 @@ from django.contrib.auth import views as auth_views
 from . import views
 
 urlpatterns = [
-    path('', views.home, name='home'),
+    path('', views.index, name='index'),
+    path('home', views.home, name='home'),
     path('register/', views.register, name='register'),
     path('login/', auth_views.LoginView.as_view(template_name='main/login.html'), name='login'),
     path('logout/', auth_views.LogoutView.as_view(template_name='main/logout.html'), name='logout'),

--- a/main/views.py
+++ b/main/views.py
@@ -1,10 +1,17 @@
 from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
 
 
-def home(request):
-    if not request.user.is_authenticated:
+def index(request):
+    if request.user.is_authenticated:
+        return home(request)
+    else:
         return render(request, 'main/landing_page.html')
-    elif request.user.is_seeker:
+
+
+@login_required
+def home(request):
+    if request.user.is_seeker:
         ''' TODO: delete current render and create a render_seeker_home
             function that will render the homepage for the seeker.'''
         return render(request, 'main/home.html')

--- a/main/views.py
+++ b/main/views.py
@@ -2,9 +2,18 @@ from django.shortcuts import render
 
 
 def home(request):
-    if request.user.is_authenticated:
+    if not request.user.is_authenticated:
+        return render(request, 'main/landing_page.html')
+    elif request.user.is_seeker:
+        ''' TODO: delete current render and create a render_seeker_home
+            function that will render the homepage for the seeker.'''
         return render(request, 'main/home.html')
-    return render(request, 'main/landing_page.html')
+    elif request.user.is_owner:
+        ''' TODO: delete current render and create a render_owner_home
+            function that will render the homepage for the owner.'''
+        return render(request, 'main/home.html')
+    else:
+        return render(request, 'main/landing_page.html')
 
 
 def register(request):

--- a/roo_me/settings.py
+++ b/roo_me/settings.py
@@ -126,4 +126,5 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 AUTH_USER_MODEL = 'users.User'
-LOGIN_REDIRECT_URL = 'home'
+LOGIN_REDIRECT_URL = 'index'
+LOGIN_URL = 'index'


### PR DESCRIPTION
# Description
The homepage needs to be rendered differently for each user type, so I created the initial routing function at `main/views.py`
`views.py` now routes the user based on his account type.
The different rendering functions still need to be developed.

## Manual Tests
Logging in with a user account with an apartment (owner) - displays `home.html`
Logging in with a user account without an apartment (shouldn't be done) - displays `landing_page.html`
Logging in with a seeker account - displays `home.html`
Logged out user - `landing_page.html`
This is good for now as we don't have the rendering functions for each user type.

### Issues closed by this PR
No issues closed by this PR yet as this is an intial PR for features that are under development.
This PR was needed for @tamirho and I to begin working on the owner and seeker homepages respectively.