### PR TITLE
Adding messages display to the web pages- DO NOT MERGE BEFORE #172

### DIFF
--- a/apartments/views.py
+++ b/apartments/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
 from main.decorators import not_logged_in_required
 from users.forms import UserCreationForm, QualitiesForm
 from .forms import ApartmentDetailsUpdateForm, ApartmentCreationForm
@@ -18,6 +19,7 @@ def update_apartment(request):
         if apartment_form.is_valid() and qualities_form.is_valid():
             apartment_form.save()
             qualities_form.save()
+            messages.success(request, "Apartment updated successfully!")
             return redirect('apartment-update')
     else:
         apartment_form = ApartmentDetailsUpdateForm(instance=request.user.apartment)
@@ -42,6 +44,7 @@ def register_apartment(request):
             apartment_profile = apartment_creation_form.save(commit=False)
             apartment_profile.owner = new_owner
             apartment_profile.save()
+            messages.success(request, f"Owner profile {new_owner} created successfully! You can log in now.")
             return redirect('login')
     else:
         user_creation_form = UserCreationForm()
@@ -57,6 +60,7 @@ def apartment_details(request, apartment_id):
     apartment_to_view = Apartment.get_apartment_by_id(apartment_id)
 
     if apartment_to_view is None:
+        messages.warning(request, "Invalid apartment request!")
         return redirect(main.views.home)
 
     return render(request, 'apartments/apartment-details.html', {

--- a/main/templates/main/base_template.html
+++ b/main/templates/main/base_template.html
@@ -67,6 +67,13 @@
     </div>
   </nav>
 
+  <!--MEASSAGE BAR-->  
+  {% if messages %}
+    {% for message in messages %}
+      <div class="alert alert-{{message.tags}}">{{message}}</div>
+    {% endfor %}
+  {% endif %}
+
   <!--CONTENT-->
   <main class="row main-body">
     <div class="col-md-2">

--- a/main/templates/main/landing_page.html
+++ b/main/templates/main/landing_page.html
@@ -3,11 +3,22 @@
 <html>
 <head>
     <title>roo.me - Start now!</title>
+    <!-- Bootstrap core CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="{% static 'css/style.css' %}">
+
 </head>
 
 <body>
+    
     <section>
+        <!--MEASSAGE BAR-->  
+        {% if messages %}
+            {% for message in messages %}
+              <div class="alert alert-{{message.tags}}">{{message}}</div>
+            {% endfor %}
+        {% endif %}
+
         <div class="text-box">
             <h1>Finding great roomates to live with<br>shouldn’t be hard.</h1>
             <a class="btn btn-full" href="{% url 'register' %}">Start now</a>

--- a/seekers/views.py
+++ b/seekers/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
 from main.decorators import not_logged_in_required
 from users.forms import UserCreationForm, QualitiesForm
 from .forms import SeekerCreationForm, SeekerUpdateForm
@@ -16,6 +17,7 @@ def register_seeker(request):
             seeker_profile = seeker_creation_form.save(commit=False)
             seeker_profile.base_user = new_base_user
             seeker_profile.save()
+            messages.success(request, f"Seeker profile {new_base_user} created successfully! You can log in now.")
             return redirect('login')
     else:
         user_creation_form = UserCreationForm()


### PR DESCRIPTION
# Description
1) Adding a printout of all recorded messages in 'base html'.
2) Adding a printout of all recorded messages in 'landing page'.
   (Does not extend 'base html')
3) Adding basic success and warning messages through the code.
EDIT: 
4) Adding JS to the bottom of 'landing page' and 'base html' to use 'close message' button.

Read more about django messages:
https://docs.djangoproject.com/en/3.2/ref/contrib/messages/

## Screenshots
![Capture1](https://user-images.githubusercontent.com/79100490/118020161-8a9cbb80-b338-11eb-8aa3-3a98ce0ec562.PNG)
![Capture2](https://user-images.githubusercontent.com/79100490/118020180-8ec8d900-b338-11eb-929f-e5b44e8b06a0.PNG)


## Manual Tests
Viewed all the messages in all pages.

## Additional Information
HOW TO USE:
When in a view, right before the render or redirect command, if you would want that 
new loaded page to display a message, just type this before the return:
messages.`<message tag>`(request, `<your message as a string>`)
message tags include 'success' / 'warning' and many more, follow the link above.
Don't forget to include `messages` from `django.contrib`

### Issues closed by this PR
fix #167 

### PR Dependencies
This PR uses javascript that was added in #172. It will need a a small rebase after the merge.