### PR TITLE
Alter redirect after register

### DIFF
--- a/apartments/views.py
+++ b/apartments/views.py
@@ -44,7 +44,7 @@ def register_apartment(request):
             apartment_profile = apartment_creation_form.save(commit=False)
             apartment_profile.owner = new_owner
             apartment_profile.save()
-            return redirect('home')
+            return redirect('login')
     else:
         user_creation_form = UserCreationForm()
         apartment_creation_form = ApartmentCreationForm()

--- a/seekers/views.py
+++ b/seekers/views.py
@@ -15,7 +15,7 @@ def register_seeker(request):
             seeker_profile = seeker_creation_form.save(commit=False)
             seeker_profile.base_user = new_base_user
             seeker_profile.save()
-            return redirect('home')
+            return redirect('login')
     else:
         user_creation_form = UserCreationForm()
         seeker_creation_form = SeekerCreationForm()


### PR DESCRIPTION
# Description
- Alter the redirect after register from `home` to `log in` (in seeker
  registration and owner registration).

## Manual Tests
- I registered as a new user and saw that I was redirected to the `login` page.

### Issues closed by this PR
Fix #169 