### PR TITLE
Introducing - 'add contact'

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -159,14 +159,14 @@ def sample_connection(db, make_seeker, make_apartment):
 
 
 @pytest.fixture
-def log_in_sample_connection_seeker(db, client):
+def log_in_sample_connection_seeker(db, sample_connection, client):
     seeker_email = "t1@m.com"
     seeker_pass = "testing"  # credentials for sample_connection.seeker
     client.login(email=seeker_email, password=seeker_pass)
 
 
 @pytest.fixture
-def log_in_sample_connection_apartment(db, client):
+def log_in_sample_connection_apartment(db, sample_connection, client):
     owner_email = "t3@m.com"
     owner_pass = "testing"  # credentials for sample_connection.apartment
     client.login(email=owner_email, password=owner_pass)

--- a/conftest.py
+++ b/conftest.py
@@ -156,3 +156,17 @@ def sample_connection(db, make_seeker, make_apartment):
     con = Connection(seeker=seeker, apartment=apartment)
     con.save()
     return con
+
+
+@pytest.fixture
+def log_in_sample_connection_seeker(db, client):
+    seeker_email = "t1@m.com"
+    seeker_pass = "testing"  # credentials for sample_connection.seeker
+    client.login(email=seeker_email, password=seeker_pass)
+
+
+@pytest.fixture
+def log_in_sample_connection_apartment(db, client):
+    owner_email = "t3@m.com"
+    owner_pass = "testing"  # credentials for sample_connection.apartment
+    client.login(email=owner_email, password=owner_pass)

--- a/contacts/urls.py
+++ b/contacts/urls.py
@@ -3,4 +3,5 @@ from . import views as contacts_views
 
 urlpatterns = [
     path('', contacts_views.contact_page, name='contact-page'),
+    path('add/<int:apartment_id>', contacts_views.add_new_contact, name='add-contact'),
 ]

--- a/contacts/views.py
+++ b/contacts/views.py
@@ -1,6 +1,10 @@
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 from django.contrib.auth.decorators import login_required
+from django.contrib import messages
 from .models import Connection, ConnectionType
+from apartments.models import Apartment
+from django.db import IntegrityError, transaction
+from django.core.exceptions import ObjectDoesNotExist
 
 
 @login_required
@@ -16,3 +20,27 @@ def contact_page(request):
         return render(request, 'contacts/contact-page-owner.html', context)
     else:
         return render(request, 'contacts/contact-page-seeker.html', context)
+
+
+@login_required
+def add_new_contact(request, apartment_id):
+    if not request.user.is_seeker:
+        messages.warning(request, "You can't send a connection request!")
+    else:
+        try:
+            apartment_to_add = Apartment.objects.get(pk=apartment_id)
+        except ObjectDoesNotExist:
+            apartment_to_add = None
+        if apartment_to_add is None:
+            messages.warning(request, "Invalid apartment request!")
+        else:
+            seeker_to_add = request.user.seeker
+            new_connection = Connection(apartment=apartment_to_add, seeker=seeker_to_add)
+            try:
+                with transaction.atomic():
+                    new_connection.save()
+                    messages.success(request, "Connection request sent!")
+            except IntegrityError:
+                messages.warning(request, "You have already sent a connection request to this user!")
+
+    return redirect('contact-page')


### PR DESCRIPTION
# Description
A seeker can now send a connection request to an owner in order to start a connection process.
1) Adding the url needs to be inserted that leads to the 'add_new_contact' view.
2) Adding the 'add_new_contact' view that handles logic and errors of a seeker trying to add
    a new connection with an owner.
3) Adding two aiding test fixtures that log in as a seeker or owner.
4) Adding tests that test all cases from success to errors trying to use the 'add contact' feature.

## Manual Tests
Tried to manually force all errors and received a fitting feedback.
Tried to add a successful contact and received a fitting feedback.

## Additional Information
How to use:
While in a seeker profile, referring him to the url "/contacts/add/`<apartment_id>`" will 
add a new pending connection request between that seeker and owner of the apartment.

Will work more nicer after the merge of messages, but not needed.

### Issues closed by this PR
fix #113 