### PR TITLE
Adding 'accept connection' and 'reject connection' options

### DIFF
--- a/contacts/models.py
+++ b/contacts/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from datetime import date
+from django.core.exceptions import ObjectDoesNotExist
 
 
 class ConnectionType(models.TextChoices):
@@ -22,7 +23,7 @@ class Connection(models.Model):
         return f"{self.apartment.owner.first_name} and {self.seeker.base_user.first_name}'s connection"
 
     def approve(self):
-        if(self.status is not ConnectionType.PENDING):
+        if(self.status != ConnectionType.PENDING):
             raise ValueError('Connection cannot be approved!')
         else:
             self.status = ConnectionType.APPROVED
@@ -35,6 +36,13 @@ class Connection(models.Model):
     @property
     def get_status(self):
         return self.status.label
+
+    @classmethod
+    def get_connection_by_id(cls, con_id):
+        try:
+            return cls.objects.get(id=con_id)
+        except ObjectDoesNotExist:
+            return None
 
     @classmethod
     def get_connections_by_user(cls, user, desired_status):

--- a/contacts/templates/contacts/contact-page-owner.html
+++ b/contacts/templates/contacts/contact-page-owner.html
@@ -4,36 +4,34 @@
 
 {% block content %}
 
-<style>body {background-color: rgb(240, 233, 233);}</style>
-
 <h1><u>Pending connections: </u></h1>
 <div class="list-group">
     {% for connection in pending_connections %}
-    <a href="#" class="list-group-item list-group-item-action" aria-current="true">
+    <div href="#" class="list-group-item list-group-item-action" aria-current="true">
       <div class="d-flex w-100 justify-content-between">
         <h5 class="mb-1">{{connection.seeker.base_user.first_name}} {{connection.seeker.base_user.last_name}}</h5>
         <small>{{connection.date_created}}</small>
       </div>
       <p class="mb-1">{{connection.seeker.about}}</p>
-      <button href="#" style="background-color: rgb(89, 146, 89);" class="btn btn-info">Approve!</button>
-      <button href="#" class="btn btn-primary">Decline!</button>
+      <a href="/contacts/approve/{{connection.pk}}" style="background-color: rgb(89, 146, 89);" class="btn btn-info">Approve!</a>
+      <a href="/contacts/reject/{{connection.pk}}" class="btn btn-primary">Decline!</a>
       <p><small><i>You can approve or decline this connection</i></small></p>
-    </a>
+    </div>
     {% endfor %}
 </div>
 
 <h1><u>Active connections: </u></h1>
 <div class="list-group">
     {% for connection in approved_connections %}
-    <a href="#" class="list-group-item list-group-item-action" aria-current="true">
+    <div href="#" class="list-group-item list-group-item-action" aria-current="true">
       <div class="d-flex w-100 justify-content-between">
         <h5 class="mb-1">{{connection.seeker.base_user.first_name}} {{connection.seeker.base_user.last_name}}</h5>
         <small>{{connection.date_created}}</small>
       </div>
       <p class="mb-1">{{connection.seeker.about}}</p>
-      <button href="#" style="background-color: rgb(179, 62, 62);" class="btn btn-info">Remove!</button>
+      <a href="/contacts/reject/{{connection.pk}}" style="background-color: rgb(179, 62, 62);" class="btn btn-info">Remove!</a>
       <p><small><i>This connection is in progress</i></small></p>
-    </a>
+    </div>
     {% endfor %}
 </div>
 {% endblock %}

--- a/contacts/templates/contacts/contact-page-seeker.html
+++ b/contacts/templates/contacts/contact-page-seeker.html
@@ -4,8 +4,6 @@
 
 {% block content %}
 
-<style>body {background-color: rgb(233, 229, 229);}</style>
-
 <h1><u>Pending connections: </u></h1>
 <div class="list-group">
     {% for connection in pending_connections %}

--- a/contacts/urls.py
+++ b/contacts/urls.py
@@ -4,4 +4,5 @@ from . import views as contacts_views
 urlpatterns = [
     path('', contacts_views.contact_page, name='contact-page'),
     path('add/<int:apartment_id>', contacts_views.add_new_contact, name='add-contact'),
+    path('<action>/<int:connection_id>', contacts_views.approve_or_reject_contact, name='approve-reject-contact'),
 ]

--- a/contacts/views.py
+++ b/contacts/views.py
@@ -44,3 +44,29 @@ def add_new_contact(request, apartment_id):
                 messages.warning(request, "You have already sent a connection request to this user!")
 
     return redirect('contact-page')
+
+
+@login_required
+def approve_or_reject_contact(request, action, connection_id):
+    connection_to_action = Connection.get_connection_by_id(connection_id)
+    if connection_to_action is None:
+        messages.warning(request, "Invalid connection request!")
+    else:
+        connection_owner = connection_to_action.apartment.owner
+        connection_seeker = connection_to_action.seeker.base_user
+        if request.user != connection_owner:
+            messages.warning(request, "You are not allowed to take action on this connection!")
+        else:
+            if action == 'approve':
+                try:
+                    connection_to_action.approve()
+                    messages.success(request, f"You can now contact {connection_seeker.first_name}!")
+                except ValueError:
+                    messages.warning(request, "Can't approve this connection!")
+            elif action == 'reject':
+                connection_to_action.reject()
+                messages.success(request, f"{connection_seeker.first_name} won't bother you anymore!")
+            else:
+                messages.warning(request, "Invalid connection action!")
+
+    return redirect('contact-page')


### PR DESCRIPTION
# Description
After receiving a connection request, an owner can now approve or reject it.
1) Adding a class method to 'Connection' model - get_connection_by_id.
2) Adding urls and a view to handle logic and errors of approving and rejecting a connection, plus giving feedback to the user 
    through messages.
3) Altering contact page templates - adding redirects when clicking 'approve' or 'reject' (to the new url).
4) Adding tests for the new features. 

## Screenshots
![Capture](https://user-images.githubusercontent.com/79100490/118376558-65fa4b00-b5a7-11eb-810b-0785daaad3dc.PNG)


## Manual Tests
Tried to manually force all errors and received fitting feedback.
Tried to approve a pending connection and saw it updating in both seeker and owner contacts page.
Tried to reject a pending connection and saw it updating in both seeker and owner contacts page.

## Additional Information
NOTE: changed some lines in the code from 'is not' to '!=' as I read that 'is not' should only be applied when comparing to `None`.
HOW TO USE:
- for an owner to approve a pending connection he needs to access "/contacts/approve/`<connection_id>`
- for an owner to reject a pending or existing connection he needs to access "/contacts/reject/`<connection_id>`
- where `<connection_id>` is the pk of the connection in Connection model.

### Issues closed by this PR
fix #173 
fix #174 

### PR Dependencies
DEPENDS ON #175 - Right now this PR is PACKED but after a rebase once #175 is merged it will be a lighter.