### PR TITLE
Create the search mechanism in the `search` app

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@ from apartments.models import Apartment, City
 from contacts.models import Connection
 from seekers.forms import SeekerCreationForm
 from apartments.forms import ApartmentCreationForm
+from search.forms import SearchForm
 from users.forms import UserCreationForm
 import pytest
 
@@ -27,6 +28,13 @@ def user_model(db):
 @pytest.fixture
 def city_model(db):
     new_city = City(cityName='nice_city')
+    new_city.save()
+    return new_city
+
+
+@pytest.fixture
+def city_model_Tel_Aviv(db):
+    new_city = City(cityName='Tel Aviv')
     new_city.save()
     return new_city
 
@@ -73,6 +81,48 @@ def apartment_model(db, city_model):
 
 
 @pytest.fixture
+def apart_success_search(db, city_model_Tel_Aviv):
+    new_owner = get_user_model().objects.create_user(
+        'apartmentemailsuccessfulsearch@address.com', 'owner', 'own', '1900-01-01', 'password'
+    )
+    new_owner.save()
+    new_apartment = Apartment(
+        owner=new_owner,
+        city=city_model_Tel_Aviv,
+        address='street',
+        rent=2500,
+        num_of_roomates=2,
+        num_of_rooms=3,
+        start_date='2021-01-01',
+        about='Hey!',
+        image_url='www.some-url.com',
+    )
+    new_apartment.save()
+    return new_apartment
+
+
+@pytest.fixture
+def apart2_success_search(db, city_model_Tel_Aviv):
+    new_owner = get_user_model().objects.create_user(
+        'apartment2emailsuccessfulsearch@address.com', 'owner', 'own', '1900-01-01', 'password'
+    )
+    new_owner.save()
+    new_apartment = Apartment(
+        owner=new_owner,
+        city=city_model_Tel_Aviv,
+        address='street',
+        rent=2750,
+        num_of_roomates=2,
+        num_of_rooms=3,
+        start_date='2020-07-17',
+        about='Hey!',
+        image_url='www.some-url.com',
+    )
+    new_apartment.save()
+    return new_apartment
+
+
+@pytest.fixture
 def valid_user_creation_form(db):
     return UserCreationForm(data={
         'email': 'formTest@mail.com',
@@ -107,6 +157,18 @@ def valid_apartment_creation_form(db, city_model):
         'num_of_rooms': 2,
         'start_date': '2020-1-1',
         'about': 'about',
+    })
+
+
+@pytest.fixture
+def valid_search_form(db, city_model_Tel_Aviv):
+    return SearchForm(data={
+        'city': city_model_Tel_Aviv,
+        'start_date': '2021-01-01',
+        'min_rent': 2000,
+        'max_rent': 3000,
+        'num_of_roomates': 2,
+        'num_of_rooms': 3,
     })
 
 

--- a/search/forms.py
+++ b/search/forms.py
@@ -1,0 +1,21 @@
+from django import forms
+from seekers.models import Seeker
+from django.core.validators import MinValueValidator
+
+
+class SearchForm(forms.ModelForm):
+    min_rent = forms.IntegerField(validators=[MinValueValidator(limit_value=0)])
+    max_rent = forms.IntegerField(validators=[MinValueValidator(limit_value=0)])
+    num_of_roomates = forms.IntegerField(validators=[MinValueValidator(limit_value=0)])
+    num_of_rooms = forms.IntegerField(validators=[MinValueValidator(limit_value=0)])
+
+    class Meta:
+        model = Seeker
+        fields = [
+            'city',
+            'start_date',
+            'min_rent',
+            'max_rent',
+            'num_of_roomates',
+            'num_of_rooms',
+            ]

--- a/search/templates/search/results.html
+++ b/search/templates/search/results.html
@@ -1,0 +1,24 @@
+{% extends "main/base_template.html" %}
+{% load crispy_forms_tags %}
+
+{% block title %} 
+   Roo.me - Results
+{% endblock %}
+
+{% block content %}
+    <h1>Hey {{ loggedUser.first_name }}!</h1>
+    {% if filteredApartments%}
+    <h2>Here are all your filtered apartments</h2>
+    <br>
+    
+    {% for aprt in filteredApartments %}
+    <li> {{ aprt }} </li>
+    {% endfor %}
+
+    {% else %}
+    <h2>Sorry, no filtered apartments was found.</h2> 
+    {% endif %}
+
+    <br>
+    <a href="">New search</a>
+{% endblock %}

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -1,11 +1,24 @@
 {% extends "main/base_template.html" %}
+{% load crispy_forms_tags %}
 
-{% block title %}
-    Roo.me - Search
+{% block title %} 
+   Roo.me - Search
 {% endblock %}
 
-
 {% block content %}
-<h1>Search mechanism - Apartment oriented<br>
-Coming Soon</h1>
+<div>
+    <h1>Hey {{ loggedUser.first_name }}!</h1>
+    <h2>Search for apartments now!</h2>
+</div>
+<div> 
+    <form method="POST">
+        {% csrf_token %}
+        <fieldset class="form-group">
+            {{ searchForm|crispy }}
+            <button type="submit">Search!</button>
+        </fieldset>
+    </form>
+    <h8>*This preferences are temporary and can be modified.</h8>
+
+</div>
 {% endblock %}

--- a/search/tests.py
+++ b/search/tests.py
@@ -1,3 +1,86 @@
-# from django.test import TestCase
+import pytest
+from django.urls import reverse
+from search.forms import SearchForm
+from search.views import get_filtered_apartments
 
-# Tests will be created here.
+
+@pytest.mark.django_db
+class TestViews:
+
+    def test_search_view_as_owner(self, client, apartment_model):
+        client.login(email='apartmentemail@address.com', password='password')
+        url = reverse('search')
+        response = client.get(url)
+        assert response.status_code == 200
+        assert b"Search for apartments now!" in response.content
+
+    def test_search_view_as_seeker(self, client, seeker_model):
+        client.login(email='seekeremail@address.com', password='password')
+        url = reverse('search')
+        response = client.get(url)
+        assert response.status_code == 200
+        assert b"Search for apartments now!" in response.content
+
+    def test_search_view_not_logged_user(self, client):
+        url = reverse('search')
+        response = client.get(url)
+        assert response.status_code == 302
+
+
+@pytest.mark.parametrize(
+    'city, start_date, min_rent, max_rent, num_of_roomates, num_of_rooms, validity',
+    [
+        ('city_model', '2021-02-02', 2000, 3000, 2, 3, True),
+        ('city_model', '', 2000, 3000, 2, 3, False),
+        ('city_model', '2021-02-02', None, 3000, 2, 3, False),
+        ('city_model', '2021-02-02', 2000, None, 2, 3, False),
+        ('city_model', '2021-02-02', 2000, 3000, None, 3, False),
+        ('city_model', '2021-02-02', 2000, 3000, 2, None, False),
+        ('city_model', '2021-13-02', 2000, 3000, 2, 3, False),
+        ('city_model', '2021-02-31', 2000, 3000, 2, 3, False),
+        ('city_model', '2021-02-02', -2, 3000, 2, 3, False),
+        ('city_model', '2021-02-02', 2000, -2, 2, 3, False),
+        ('city_model', '2021-02-02', 2000, 3000, -2, 3, False),
+        ('city_model', '2021-02-02', 2000, 3000, 2, -3, False),
+    ])
+@pytest.mark.django_db
+def test_search_form_validity(city, start_date, min_rent, max_rent, num_of_roomates, num_of_rooms, validity, request):
+    city = request.getfixturevalue(city)
+    form = SearchForm(data={
+        'city': city,
+        'start_date': start_date,
+        'min_rent': min_rent,
+        'max_rent': max_rent,
+        'num_of_roomates': num_of_roomates,
+        'num_of_rooms': num_of_rooms,
+    })
+    assert form.is_valid() is validity
+
+
+@pytest.mark.django_db
+def test_valid_form_is_valid(valid_search_form):
+    assert valid_search_form.is_valid()
+
+
+@pytest.mark.django_db
+def test_not_successful_get_filtered_apartments(client, valid_search_form):
+    filtered_apartments = get_filtered_apartments(valid_search_form)
+    result = filtered_apartments.count()
+    expectedResult = 0
+    assert result is expectedResult
+
+
+@pytest.mark.django_db
+def test_success_get_filtered_aparts(client, valid_search_form, apart_success_search):
+    filtered_apartments = get_filtered_apartments(valid_search_form)
+    result = filtered_apartments.count()
+    expectedResult = 1
+    assert result is expectedResult
+
+
+@pytest.mark.django_db
+def test_multiple_success_get_filtered_aparts(client, valid_search_form, apart_success_search, apart2_success_search):
+    filtered_apartments = get_filtered_apartments(valid_search_form)
+    result = filtered_apartments.count()
+    expectedResult = 2
+    assert result is expectedResult

--- a/search/views.py
+++ b/search/views.py
@@ -1,5 +1,55 @@
 from django.shortcuts import render
+from django.contrib.auth.decorators import login_required
+from .forms import SearchForm
+from apartments.models import Apartment, City
+from datetime import datetime
 
 
+@login_required
 def search(request):
-    return render(request, 'search/search.html')
+    if request.method == 'POST':
+        search_form = SearchForm(request.POST)
+        if search_form.is_valid():
+            form = SearchForm(request.POST)
+            filtered_apartments = get_filtered_apartments(form)
+            context = {
+                'filteredApartments': filtered_apartments,
+                'loggedUser': request.user
+            }
+            return render(request, 'search/results.html', context)
+    else:
+        if request.user.is_owner is True:
+            search_form = SearchForm(
+                instance=request.user.apartment,
+                initial={
+                    'min_rent': request.user.apartment.rent - 500,
+                    'max_rent': request.user.apartment.rent + 500}
+            )
+        elif request.user.is_seeker is True:
+            search_form = SearchForm(instance=request.user.seeker)
+        else:
+            search_form = SearchForm({
+                'city': City.objects.get(cityName='Tel Aviv'),
+                'start_date': datetime.now(),
+                'min_rent': 1000,
+                'max_rent': 3000,
+                'num_of_roomates': 3,
+                'num_of_rooms': 4
+            })
+    context = {
+        'searchForm': search_form,
+        'loggedUser': request.user
+    }
+    return render(request, 'search/search.html', context)
+
+
+def get_filtered_apartments(form):
+    return Apartment.objects.filter(**{
+            'is_relevant': True,
+            'start_date__lte': form['start_date'].value(),
+            'city': form['city'].value(),
+            'rent__gte': form['min_rent'].value(),
+            'rent__lte': form['max_rent'].value(),
+            'num_of_roomates': form['num_of_roomates'].value(),
+            'num_of_rooms': form['num_of_rooms'].value()
+        })


### PR DESCRIPTION
# Description
In this PR the search mechanism was created in the `search` app.

The logged-in user will be able to search apartments with preferences and get results accordingly.
By default the preferences will be filled according to the logged-in user type:

Seeker - with the seeker preferences.
Owner - with the apartment qualities.
Admin - with arbitrary preferences.

NOTES:
The search mechanism is Apartment oriented.
The Search mechanism works only for logged-in users.
The search preferences are temporary.
The search preferences can be modified.

## form screenshots:
![image](https://user-images.githubusercontent.com/58184521/118381124-6965f480-b5f0-11eb-8751-fe895d946fb9.png)
## results Screenshots:
![image](https://user-images.githubusercontent.com/58184521/118381193-1d677f80-b5f1-11eb-8060-51cd6b39b3d7.png)

## Additional Information
In the next PR's the 'results.html' file should be upgraded.
The filtered apartments will be shown in cards with a Yes\no interface.
will be created by @nadavsu.

## PR workflow
- created a form for the search mechanism
- added templates for 'search' app …
- created the search mechanism in `views`.
- created test for the 'search' app.

### Issues closed by this PR
fix: #116, #119.

### PR Dependencies
None.