### PR TITLE
Add user-to-user matching algorithm

### DIFF
--- a/apartments/models.py
+++ b/apartments/models.py
@@ -25,7 +25,7 @@ class Apartment(models.Model):
     image_url = models.TextField(blank=True)
 
     def __str__(self):
-        return f"Owner:{self.owner}, Addres:{self.address}, City:{self.city}"
+        return f"Owner:{self.owner}, Address:{self.address}, City:{self.city}"
 
     @classmethod
     def get_apartment_by_id(cls, id):

--- a/seekers/models.py
+++ b/seekers/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from roo_me.settings import AUTH_USER_MODEL
+from apartments.models import Apartment
 
 
 class Seeker(models.Model):
@@ -14,3 +15,25 @@ class Seeker(models.Model):
 
     def __str__(self):
         return f"Seeker:{self.base_user}"
+
+    def get_matched_apartments(self):
+        apartments = self.get_all_relevant_apartments()
+        return sorted(
+            apartments,
+            key=lambda apt: apt.owner.get_matching_score(self.base_user),
+            reverse=True
+        )[:10]
+
+    '''TODO: Delete this function and use the search function from the search application instead.
+    This is a temporary function - it was only written in order to develop the feature.
+    DO NOT USE once the search application is merged.'''
+    def get_all_relevant_apartments(self):
+        return Apartment.objects.filter(**{
+                'is_relevant': True,
+                'city': self.city,
+                'rent__lte': self.max_rent,
+                'rent__gte': self.min_rent,
+                'num_of_roomates__lte': self.num_of_roomates,
+                'num_of_rooms': self.num_of_rooms,
+                'start_date__lte': self.start_date,
+            })

--- a/users/models.py
+++ b/users/models.py
@@ -85,6 +85,14 @@ class User(AbstractBaseUser, PermissionsMixin):
     def __str__(self):
         return self.email
 
+    def get_matching_score(self, other_user):
+        intersect = other_user.hobbies.all().intersection(self.hobbies.all())
+        union = other_user.hobbies.all().union(self.hobbies.all())
+        if (len(union) == 0):
+            return 0
+        else:
+            return len(intersect) / len(union)
+
     @property
     def is_seeker(self):
         try:


### PR DESCRIPTION
# Description
Added a function which returns a matching score between two users which is used to rank the different apartments for the seeker. It works by dividing the number of similar hobbies shared between the two users by the total number of hobbies between the two users. Returns a number between 0 and 1.

## Manual Tests
All users with the same score - passed
4 users with different scores with a QuerySet limit of 3 apartments - passed
4 users with different scores and a QuerySet limit of 3 apartments - passed
3 users with different scores and a QuerySet size limit of 3 apartments - passed

## Additional Information
`get_all_relevant_apartments` is a temporary function which was written in order to create this feature. Once the search feature is created, this function must be deleted, as we'll use the function in the search feature.

### Issues closed by this PR
Fixes #59