### PR TITLE
`about` field wasn't shown in `apartment-details.html` file

### DIFF
--- a/apartments/templates/apartments/apartment-details.html
+++ b/apartments/templates/apartments/apartment-details.html
@@ -42,7 +42,7 @@
             <dd class="col-sm-9">{{ apartment.start_date }}</dd>
 
             <dt class="col-sm-3 text-truncate">About</dt>
-            <dd class="col-sm-9"> {{ apartment.aboute }}</dd>
+            <dd class="col-sm-9"> {{ apartment.about }}</dd>
         </dl>
         <small class="text-muted">posted in {{ apartment.date_posted }}</small>
     <div class="card-img">


### PR DESCRIPTION
# Description
Because of a code error - `aboute` instead of `about`.
The `about` field wasn't shown in `apartment-details.html` file.
Fixed the code error. Now the about field is shown.

## Screenshots
![image](https://user-images.githubusercontent.com/58184521/118982711-5c485d00-b984-11eb-86da-fe5ed4e28d0f.png)

### Issues closed by this PR
fix: #205 

### PR Dependencies
NONE