### PR TITLE
Correct forms labels

### DIFF
--- a/search/forms.py
+++ b/search/forms.py
@@ -1,13 +1,14 @@
 from django import forms
 from seekers.models import Seeker
-from django.core.validators import MinValueValidator
+from django.core.validators import MinValueValidator    
 
 
 class SearchForm(forms.ModelForm):
-    min_rent = forms.IntegerField(validators=[MinValueValidator(limit_value=0)])
-    max_rent = forms.IntegerField(validators=[MinValueValidator(limit_value=0)])
-    num_of_roomates = forms.IntegerField(validators=[MinValueValidator(limit_value=0)])
-    num_of_rooms = forms.IntegerField(validators=[MinValueValidator(limit_value=0)])
+    min_rent = forms.IntegerField(label='Minimum rent', validators=[MinValueValidator(limit_value=0)])
+    max_rent = forms.IntegerField(label='Maximum rent', validators=[MinValueValidator(limit_value=0)])
+    num_of_roomates = forms.IntegerField(label='Number of roomates', validators=[MinValueValidator(limit_value=0)])
+    num_of_rooms = forms.IntegerField(label='Number of rooms', validators=[MinValueValidator(limit_value=0)])
+    start_date = forms.DateField(label='Start date [YYYY-MM-DD]')
 
     class Meta:
         model = Seeker

--- a/search/forms.py
+++ b/search/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from seekers.models import Seeker
-from django.core.validators import MinValueValidator    
+from django.core.validators import MinValueValidator
 
 
 class SearchForm(forms.ModelForm):

--- a/users/forms.py
+++ b/users/forms.py
@@ -5,6 +5,7 @@ from .models import User
 class UserCreationForm(forms.ModelForm):
     password1 = forms.CharField(label="Password", widget=forms.PasswordInput())
     password2 = forms.CharField(label="Password confirmation", widget=forms.PasswordInput())
+    birth_date = forms.DateField(label='Birthday')
 
     class Meta:
         model = User
@@ -51,6 +52,7 @@ class QualitiesForm(forms.ModelForm):
 
 
 class UserUpdateForm(forms.ModelForm):
+    birth_date = forms.DateField(label='Birthday')
 
     class Meta:
         model = User

--- a/users/templates/users/user-details.html
+++ b/users/templates/users/user-details.html
@@ -20,7 +20,7 @@
             <dt class="col-sm-3">Email</dt>
             <dd class="col-sm-9">{{ user.email }}</dd>
 
-            <dt class="col-sm-3">Birth Date</dt>
+            <dt class="col-sm-3">Birthday</dt>
             <dd class="col-sm-9">{{ user.birth_date }}</dd>
         </dl>
         <div class="col-6">


### PR DESCRIPTION
# Description
- Added format for the date label - [YYYY-MM-DD].
- some of the forms labels were shortcuts, corrected them.
examples:
`min` - `Minimum`.
`num` - `Number`.

## Screenshots
![image](https://user-images.githubusercontent.com/58184521/119022074-dc80b980-b9a8-11eb-97c7-68c7e2a17741.png)


### Issues closed by this PR
fix: #214.

### PR Dependencies
None.