### PR TITLE
Fix date and rent in search mechanism

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -93,7 +93,7 @@ def apart_success_search(db, city_model_Tel_Aviv):
         rent=2500,
         num_of_roomates=2,
         num_of_rooms=3,
-        start_date='2021-01-01',
+        start_date='2021-03-02',
         about='Hey!',
         image_url='www.some-url.com',
     )
@@ -114,7 +114,7 @@ def apart2_success_search(db, city_model_Tel_Aviv):
         rent=2750,
         num_of_roomates=2,
         num_of_rooms=3,
-        start_date='2020-07-17',
+        start_date='2021-02-02',
         about='Hey!',
         image_url='www.some-url.com',
     )
@@ -164,7 +164,7 @@ def valid_apartment_creation_form(db, city_model):
 def valid_search_form(db, city_model_Tel_Aviv):
     return SearchForm(data={
         'city': city_model_Tel_Aviv,
-        'start_date': '2021-01-01',
+        'start_date': '2021-03-03',
         'min_rent': 2000,
         'max_rent': 3000,
         'num_of_roomates': 2,

--- a/search/views.py
+++ b/search/views.py
@@ -29,7 +29,7 @@ def search(request):
                     instance=request.user.apartment,
                     initial={
                         'min_rent': 1,
-                        'max_rent': request.user.apartment.rent + 500}
+                        'max_rent': 500}
                 )
         elif request.user.is_seeker is True:
             search_form = SearchForm(instance=request.user.seeker)
@@ -54,7 +54,7 @@ def search(request):
 def get_filtered_apartments(form):
     return Apartment.objects.filter(**{
             'is_relevant': True,
-            'start_date__gte': form['start_date'].value(),
+            'start_date__lte': form['start_date'].value(),
             'city': form['city'].value(),
             'rent__gte': form['min_rent'].value(),
             'rent__lte': form['max_rent'].value(),

--- a/search/views.py
+++ b/search/views.py
@@ -17,22 +17,30 @@ def search(request):
         filtered_apartments = None
         results = None
         if request.user.is_owner is True:
-            search_form = SearchForm(
-                instance=request.user.apartment,
-                initial={
-                    'min_rent': request.user.apartment.rent - 500,
-                    'max_rent': request.user.apartment.rent + 500}
-            )
+            if request.user.apartment.rent > 500:
+                search_form = SearchForm(
+                    instance=request.user.apartment,
+                    initial={
+                        'min_rent': request.user.apartment.rent - 500,
+                        'max_rent': request.user.apartment.rent + 500}
+                )
+            else:
+                search_form = SearchForm(
+                    instance=request.user.apartment,
+                    initial={
+                        'min_rent': 1,
+                        'max_rent': request.user.apartment.rent + 500}
+                )
         elif request.user.is_seeker is True:
             search_form = SearchForm(instance=request.user.seeker)
         else:
             search_form = SearchForm({
                 'city': City.objects.get(cityName='Tel Aviv'),
                 'start_date': datetime.now(),
-                'min_rent': 1000,
+                'min_rent': 2000,
                 'max_rent': 3000,
-                'num_of_roomates': 3,
-                'num_of_rooms': 4
+                'num_of_roomates': 2,
+                'num_of_rooms': 3
             })
     context = {
         'searchForm': search_form,
@@ -46,7 +54,7 @@ def search(request):
 def get_filtered_apartments(form):
     return Apartment.objects.filter(**{
             'is_relevant': True,
-            'start_date__lte': form['start_date'].value(),
+            'start_date__gte': form['start_date'].value(),
             'city': form['city'].value(),
             'rent__gte': form['min_rent'].value(),
             'rent__lte': form['max_rent'].value(),


### PR DESCRIPTION
# Description
Fix the search mechanism. Updated test to match the updated mechanism.

- Fixed the filter `start_date` `greater or equal. The mechanism will get results of all dates from the start date and previous.
Example: 
start_date: 22\05\2021.
Show apartment with start_date: 10/05/2021.
Don't show apartment with start_date: 30/05/2021.

- When rent was under 500, the mechanism would show a negative number. Changed it to a minimum 1.

- changed the default filters.

- updated the search test.

### Issues closed by this PR
fix: #235, #236.

### PR Dependencies
NONE!