### PR TITLE
Add image url field to ApartmentCreationForm

### DIFF
--- a/apartments/forms.py
+++ b/apartments/forms.py
@@ -36,6 +36,7 @@ class ApartmentCreationForm(forms.ModelForm):
             'num_of_rooms',
             'start_date',
             'about',
+            'image_url',
         )
 
     def save(self, commit=False):


### PR DESCRIPTION
# Description
- Add image url field to ApartmentCreationForm

## Screenshots
<img width="945" alt="Capture1" src="https://user-images.githubusercontent.com/65215909/119219658-3db2a500-baef-11eb-8512-6f230b38de1f.PNG">

### Issues closed by this PR
Fixes #238 
