### PR TITLE
Adding ability to decline apartments!

### DIFF
--- a/contacts/urls.py
+++ b/contacts/urls.py
@@ -4,6 +4,7 @@ from . import views as contacts_views
 urlpatterns = [
     path('', contacts_views.contact_page, name='contact-page'),
     path('add/<int:apartment_id>', contacts_views.add_new_contact, name='add-contact'),
+    path('decline/<int:apartment_id>', contacts_views.decline_apartment, name='decline-contact'),
     path('chat/<int:connection_id>', contacts_views.chat, name='chat'),
     path('<action>/<int:connection_id>', contacts_views.approve_or_reject_contact, name='approve-reject-contact'),
 ]


### PR DESCRIPTION
# Description
1) Adding view and paths for the decline logic.
2) Adding tests on the matter.

## Manual Tests
Tried to decline via the url.

## Additional Information
How to use: to decline an apartment for further use, reach the url:
'/contacts/decline/`<apartment_id>`' and this apartment will no longer pop up.

### Issues closed by this PR
fix #242 

