### PR TITLE
Fix navbar links

### DIFF
--- a/apartments/templates/apartments/apartment_register.html
+++ b/apartments/templates/apartments/apartment_register.html
@@ -3,6 +3,8 @@
 
 {% block title %}Roo.me - Register as owner{% endblock %}
 
+{% block navbar %}{% endblock %}
+
 {% block sidebar %}
 {% endblock %}
 

--- a/seekers/templates/seekers/seeker_register.html
+++ b/seekers/templates/seekers/seeker_register.html
@@ -3,6 +3,8 @@
 
 {% block title %}Roo.me - Register as Seeker{% endblock %}
 
+{% block navbar %}{% endblock %}
+
 {% block sidebar %}
 {% endblock %}
 


### PR DESCRIPTION
# Description
Removed the links in the navbar at registration for seekers and apartments.

## Screenshots
![Screen Shot 2021-05-22 at 11 48 48](https://user-images.githubusercontent.com/53123142/119220785-d7308580-baf4-11eb-83c9-0ec816744536.png)