### PR TITLE
Alter search urls import name

### DIFF
--- a/search/urls.py
+++ b/search/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
-from . import views as seeker_views
+from . import views as search_views
 
 
 urlpatterns = [
-    path('', seeker_views.search, name='search'),
+    path('', search_views.search, name='search'),
 ]


### PR DESCRIPTION
# Description
Alter the import name in the `search/urls.py` to a more accurate name.

### Issues closed by this PR
Fixes #248 