### PR TITLE
Add img-urls to the cards

### DIFF
--- a/apartments/templates/apartments/owner-homepage.html
+++ b/apartments/templates/apartments/owner-homepage.html
@@ -114,7 +114,7 @@
 
                         <div class="tab-pane fade" id="rmt-{{apartment.owner.id}}" role="tabpanel"
                             aria-labelledby="rmt-tab-{{apartment.owner.id}}">
-                            <img src="../../static/img/user-account.png" class="card-img-top" alt={{apartment.address}}>
+                            <img src="{{apartment.owner.image_url}}" class="card-img-top" alt={{apartment.address}}>
                             <div class="card-body">
                                 <h5 class="card-title">{{apartment.owner.first_name}} {{apartment.owner.last_name}}</h5>
                                 <h6 class="card-subtitle mb-2 text-muted">{{apartment.address}}, {{apartment.city}}</h6>

--- a/main/templates/main/base_template.html
+++ b/main/templates/main/base_template.html
@@ -88,7 +88,7 @@
     <div class="col-md-2">
       {% block sidebar %}
         <div class="card shadow p-3 mb-5 bg-white rounded">
-          <img src="{{ request.user.image_url }}" alt="Profile picture" id="profile_picture">
+          <img class="card-img-top" src="{{ request.user.image_url }}" alt="Profile picture" id="profile_picture">
             <div class="card-body">
               <h5 class="card-title username">{{request.user.first_name}} {{request.user.last_name}}</h5>
               {%if request.user.is_seeker == True %}<i><h5 class="card-title type">Seeker</h5></i>

--- a/seekers/templates/seekers/seeker_home.html
+++ b/seekers/templates/seekers/seeker_home.html
@@ -58,7 +58,7 @@
             </div>
 
             <div class="tab-pane fade" id="rmt-{{apartment.owner.id}}" role="tabpanel" aria-labelledby="rmt-tab-{{apartment.owner.id}}">
-              <img src="../../static/img/user-account.png" class="card-img-top" alt={{apartment.address}}>
+              <img src="{{apartment.owner.image_url}}" class="card-img-top" alt={{apartment.address}}>
               <div class="card-body">
                 <h5 class="card-title">{{apartment.owner.first_name}} {{apartment.owner.last_name}}</h5>
                 <h6 class="card-subtitle mb-2 text-muted">{{apartment.address}}, {{apartment.city}}</h6>


### PR DESCRIPTION
# Description
Link between image tags and the user's profile image in the `seeker` and `owner` home page.

## Screenshots

<img width="947" alt="Capture" src="https://user-images.githubusercontent.com/65215909/119231505-eb42aa00-bb29-11eb-8423-92b6ce716798.PNG">

### Issues closed by this PR
Fixes #269 
