### PR TITLE
Fixing chat not entirely fitting screen

### DIFF
--- a/contacts/templates/contacts/chat.html
+++ b/contacts/templates/contacts/chat.html
@@ -8,11 +8,6 @@
 {% block content %}
 
 <div class="container">
-  {% if user.is_seeker %}
-    <h3 class=" text-center">Chat with {{chat_messages.first.connection.apartment.owner.first_name}}</h3>
-  {% else %}
-    <h3 class=" text-center">Chat with {{chat_messages.first.connection.seeker.base_user.first_name}}</h3>
-  {% endif %}
   <div class="messaging">
         <div class="inbox_msg">
           <div class="inbox_people">
@@ -45,6 +40,12 @@
         </div>
           <div class="mesgs">
             <div class="msg_history">
+              {% if user.is_seeker %}
+                <h3 class=" text-center">Chat with {{chat_messages.first.connection.apartment.owner.first_name}}</h3>
+              {% else %}
+                <h3 class=" text-center">Chat with {{chat_messages.first.connection.seeker.base_user.first_name}}</h3>
+              {% endif %}
+              
               {% for msg in chat_messages %}
               {% if msg.author == user %}
               <div class="outgoing_msg">


### PR DESCRIPTION
# Description
The chat box was a bit larger than an ordinary screen, causing you to scroll down on the page every time you send a message in order to be able to send another message (the message inbox is invisible until scrolling down).
After this change, the whole chat box including the message inbox is visible without scrolling down, allowing users to have a better experience.

## Screenshots
![Capture](https://user-images.githubusercontent.com/79100490/119466303-3ecc1800-bd23-11eb-834e-0087825b1e30.PNG)


## Manual Tests
Tried to use the chat, no side effects. 

## Additional Information
Functionality of the chat stays the same.

### Issues closed by this PR
fix #287 
